### PR TITLE
Remove query change on theme update event

### DIFF
--- a/src/Main.cs
+++ b/src/Main.cs
@@ -38,7 +38,6 @@ namespace Flow.Launcher.Plugin.SpeedTest
             context.API.ActualApplicationThemeChanged += (_, __) =>
             {
                 UpdateIcon();
-                try { _context?.API.ChangeQuery(_context.CurrentPluginMetadata.ActionKeyword, true); } catch { }
             };
 
             return Task.CompletedTask;


### PR DESCRIPTION
Removed code that triggered a query change when the application's theme changed. If in that time, the plugin have other query, it will override the previous query.

Resolve #2.